### PR TITLE
Fix issue with no state set

### DIFF
--- a/src/OauthReceiver/index.js
+++ b/src/OauthReceiver/index.js
@@ -61,8 +61,10 @@ export class OauthReceiver extends React.Component {
 
       const queryResult = this.parseQuerystring();
       const { error, error_description, code } = queryResult;
-      const state = JSON.parse(queryResult.state);
-      this.setState(() => ({ state }));
+      const state = JSON.parse(queryResult.state || null);
+      if (state) {
+        this.setState(() => ({ state }));
+      }
 
       if (error != null) {
         const err = new Error(error_description);


### PR DESCRIPTION
Allow for state to be undefined when it reaches the receiver. If it is undefined, then allow for `JSON.parse` and only set the state if it's not null.

Closes #21 