### PR TITLE
Allow for fetch options

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,15 +169,16 @@ redirected from the OAuth2-provider.
 
 #### Props
 
-| Prop           | Type                 | Required | Default | Description                                                                             |
-| :------------- | :------------------- | :------- | :------ | :-------------------------------------------------------------------------------------- |
-| `tokenUrl`     | `string`             | yes      | -       | The full url to the token endpoint, provided by the service                             |
-| `clientId`     | `string`             | yes      | -       | Your client id from the service provider (remember to keep it secret!)                  |
-| `clientSecret` | `string`             | yes      | -       | Your client secret from the service provider (remember to keep it secret!)              |
-| `redirectUri`  | `string`             | yes      | -       | The URL where the provider has redirected your user (used to verify auth)               |
-| `args`         | `object`             | no       | -       | Args will be attatched to the request to the token endpoint. Will be serialized by `qz` |
-| `location`     | `{ search: string }` | no       | -       | Used to extract info from querystring [(read more below)](#location-and-querystring)    |
-| `querystring`  | `string`             | no       | -       | Used to extract info from querystring [(read more below)](#location-and-querystring)    |
+| Prop             | Type                 | Required | Default | Description                                                                             |
+| :--------------- | :------------------- | :------- | :------ | :-------------------------------------------------------------------------------------- |
+| `tokenUrl`       | `string`             | yes      | -       | The full url to the token endpoint, provided by the service                             |
+| `clientId`       | `string`             | yes      | -       | Your client id from the service provider (remember to keep it secret!)                  |
+| `clientSecret`   | `string`             | yes      | -       | Your client secret from the service provider (remember to keep it secret!)              |
+| `redirectUri`    | `string`             | yes      | -       | The URL where the provider has redirected your user (used to verify auth)               |
+| `args`           | `object`             | no       | -       | Args will be attatched to the request to the token endpoint. Will be serialized by `qz` |
+| `location`       | `{ search: string }` | no       | -       | Used to extract info from querystring [(read more below)](#location-and-querystring)    |
+| `querystring`    | `string`             | no       | -       | Used to extract info from querystring [(read more below)](#location-and-querystring)    |
+| `tokenFetchArgs` | `object`             | no       | `{}`    | Used to fetch the token endpoint [(read more below)](#tokenfetchargs)                   |
 
 #### Events
 
@@ -258,6 +259,20 @@ provides you with a `location`-prop with all the information that
 `querystring` can be used if you want some control over the process, but
 basically it's `window.location.search`. So if it is not provided
 `<OauthReceiver />` will fetch the information from `window.location.search`.
+
+#### `tokenFetchArgs`
+
+The prop `tokenFetchArgs` can be used to change how the token is received from
+the service. For example, the token service for Facebook requires a `GET`
+request but the token service for Dropbox requires a `POST` request. You can
+change `tokenFetchArgs` to make this necessary change.
+
+The following are the default fetch args used to fetch the token but they can be
+merged and overriden with the `tokenFetchArgs`:
+
+```
+{ method: 'GET', headers: { 'Content-Type': 'application/json' }}
+```
 
 ### `createOauthFlow`
 

--- a/src/OauthReceiver/OauthReceiver.test.js
+++ b/src/OauthReceiver/OauthReceiver.test.js
@@ -82,7 +82,11 @@ describe('with custom token uri fetch args', () => {
   let api = null;
 
   beforeAll(() => {
-    api = nock('https://api.service.com/');
+    api = nock('https://api.service.com/', {
+      reqheaders: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+    });
 
     api
       .get('/oauth2/token')

--- a/src/OauthReceiver/index.js
+++ b/src/OauthReceiver/index.js
@@ -23,6 +23,9 @@ export class OauthReceiver extends React.Component {
     onAuthSuccess: PropTypes.func,
     onAuthError: PropTypes.func,
     render: PropTypes.func,
+    tokenFetchArgs: PropTypes.shape({
+      method: PropTypes.string,
+    }),
     component: PropTypes.element,
     children: PropTypes.func,
   };
@@ -34,6 +37,7 @@ export class OauthReceiver extends React.Component {
     onAuthSuccess: null,
     onAuthError: null,
     render: null,
+    tokenFetchArgs: {},
     component: null,
     children: null,
   };
@@ -52,6 +56,7 @@ export class OauthReceiver extends React.Component {
     try {
       const {
         tokenUrl,
+        tokenFetchArgs,
         clientId,
         clientSecret,
         redirectUri,
@@ -79,8 +84,10 @@ export class OauthReceiver extends React.Component {
       });
 
       const headers = new Headers({ 'Content-Type': 'application/json' });
+      const defaultFetchArgs = { method: 'POST', headers };
+      const fetchArgs = Object.assign(defaultFetchArgs, tokenFetchArgs);
 
-      fetch2(url, { method: 'POST', headers })
+      fetch2(url, fetchArgs)
         .then(response => {
           const accessToken = response.access_token;
 


### PR DESCRIPTION
This PR allows for the fetch args to be set via a prop for the `OAuthReceiver` component. This makes the component a little more general by allowing different services to override the default fetch options when fetching from the token service.

For example, the Facebook token service (`https://graph.facebook.com/v3.0/oauth/access_token`) requires a `GET` request but the Dropbox token service (`https://api.dropboxapi.com/oauth2/token`) requires a `POST`. This prop would allow the client to change the defaults.

This would also allow for additional headers to be set or the default `Content-Type` to be changed.

Closes #22 