### PR TITLE
[#32] Fix for 'h' not defined.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "module": "dist/react-oauth-flow.m.js",
   "source": "src/index.js",
   "scripts": {
-    "build": "microbundle",
+    "build": "microbundle --jsx React.createElement",
     "test": "jest",
     "lint": "eslint",
     "format": "prettier",


### PR DESCRIPTION
Ran into the issue where 'h' is not defined. After a brief rabbit hole dive I've ran into this thread 
https://github.com/developit/microbundle/issues/12#issuecomment-357475732
And the next couple of comments were really helpful.

Turns out that default "pragma" is `h` but it's possible to change to anything else, in this case `React.createElement`

The way I verified it's working is by building it, moving it to examples folder and using it in the example app. Let me know if I missed something.

Solves #32 and #31 

PS. @adambrgmn  just for visibility.